### PR TITLE
remove ufo code folding and use treesitter

### DIFF
--- a/lua/jai/capabilities.lua
+++ b/lua/jai/capabilities.lua
@@ -2,10 +2,10 @@
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 
 -- for nvim-ufo: code folding
-capabilities.textDocument.foldingRange = {
-    dynamicRegistration = false,
-    lineFoldingOnly = true
-}
+-- capabilities.textDocument.foldingRange = {
+--     dynamicRegistration = false,
+--     lineFoldingOnly = true
+-- }
 
 -- for cpm_nvim_lsp
 capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)

--- a/lua/jai/on_attach.lua
+++ b/lua/jai/on_attach.lua
@@ -1,36 +1,55 @@
 -- [[ used in every lspconfig by default ]]
 
--- Mappings.
--- See `:help vim.diagnostic.*` for documentation on any of the below functions
-local opts = { noremap=true, silent=true }
-vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, opts)
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-vim.keymap.set('n', '<space>q', vim.diagnostic.setloclist, opts)
-
 -- Use an on_attach function to only map the following keys
 -- after the language server attaches to the current buffer
 return function(client, bufnr)
-  -- Enable completion triggered by <c-x><c-o>
-  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  -- scope these keybinds to buffer for attached language server
+  -- below should only be passed 2 further arguments
+  -- NOTE: vim.keymap.set accepts direct lua functions in {rhs} argument.
+  -- Underneath, it calls vim.api.nvim_set_keymap approriately
+  local function buf_set_keymap(...) vim.keymap.set(...) end
+  -- below should only be passed 3 further arguments
+  local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end
+
+  local bufopts = { noremap=true, silent=true, buffer = bufnr }
 
   -- Mappings.
   -- See `:help vim.lsp.*` for documentation on any of the below functions
-  local bufopts = { noremap=true, silent=true, buffer=bufnr }
-  vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
-  vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
-  vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
-  vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
-  vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
-  vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wl', function()
+
+  -- Enable completion triggered by <c-x><c-o>
+  -- TODO: is this redundant with the use of nvim_cmp?
+  buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  buf_set_keymap('n', '<space>e', vim.diagnostic.open_float, bufopts)
+  buf_set_keymap('n', '[d', vim.diagnostic.goto_prev, bufopts)
+  buf_set_keymap('n', ']d', vim.diagnostic.goto_next, bufopts)
+  buf_set_keymap('n', '<space>q', vim.diagnostic.setloclist, bufopts)
+
+  buf_set_keymap('n', 'gD', vim.lsp.buf.declaration, bufopts)
+  buf_set_keymap('n', 'gd', vim.lsp.buf.definition, bufopts)
+  buf_set_keymap('n', 'K', vim.lsp.buf.hover, bufopts)
+  buf_set_keymap('n', 'gi', vim.lsp.buf.implementation, bufopts)
+  buf_set_keymap('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
+  buf_set_keymap('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
+  buf_set_keymap('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
+  buf_set_keymap('n', '<space>wl', function()
     print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
   end, bufopts)
-  vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
-  vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
-  vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
-  vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
+  buf_set_keymap('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
+  buf_set_keymap('n', '<space>rn', vim.lsp.buf.rename, bufopts)
+  buf_set_keymap('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
+  buf_set_keymap('n', 'gr', vim.lsp.buf.references, bufopts)
+
+  buf_set_keymap('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
+
+--   -- Set some keybinds conditional on server capabilities
+--   if client.server_capabilities.document_formatting then
+--     buf_set_keymap("n", "<space>f", vim.lsp.buf.formatting(), bufopts)
+--   elseif client.server_capabilities.document_range_formatting then
+--     --buf_set_keymap('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
+--     buf_set_keymap("n", "<space>f", vim.lsp.buf.formatting(), bufopts)
+--   end
+
 end
 

--- a/lua/jai/plugins.lua
+++ b/lua/jai/plugins.lua
@@ -1,5 +1,9 @@
 -- [[ plugins.lua ]]
 
+-- below path should resolve to '$HOME/.config/nvim/site/pack'
+local packer_path = vim.fn.stdpath('config') .. '/site/pack'
+
+
 vim.cmd([[packadd packer.nvim]])
 
 -- Auto recompile packages whenever this file is changed
@@ -12,7 +16,6 @@ vim.cmd([[
 
 -- load packer module each time Neovim is started
 -- sets package root to location where Packer repo was cloned
-
 return require('packer').startup({function(use)
   -- [[ Plugins Go Here ]]
 
@@ -20,8 +23,7 @@ return require('packer').startup({function(use)
   use 'wbthomason/packer.nvim'
 
 
-  -- Mason
-  -- LSP Client Configs
+  -- LSP
   use {
     "williamboman/mason.nvim",
     "williamboman/mason-lspconfig.nvim",
@@ -31,21 +33,21 @@ return require('packer').startup({function(use)
   -- LSP config for rust_analyzer nvim-lspconfig
   use('simrat39/rust-tools.nvim')
 
-  -- For each plugin that we add to packker, we delcare a `use-package` statement
+  -- For each plugin that we add to packer, we delcare a `use-package` statement
   -- The below is the form taken for packages installed from github
   use {
     'nvim-tree/nvim-tree.lua',
     branch="master",
      requires = {
-        'nvim-tree/nvim-web-devicons', -- optional, for file icons
+        'nvim-tree/nvim-web-devicons',    -- optional, for file icons
     }
   }
 
-  use { 'mhinz/vim-startify' }                       -- start screen
-  use { 'DanilaMihailov/beacon.nvim' }               -- cursor jump
+  use { 'mhinz/vim-startify' }            -- start screen
+  use { 'DanilaMihailov/beacon.nvim' }    -- cursor jump
 
   use {
-    'nvim-lualine/lualine.nvim',                     -- statusline
+    'nvim-lualine/lualine.nvim',          -- statusline
     requires =
         {
           'nvim-tree/nvim-web-devicons',
@@ -57,16 +59,16 @@ return require('packer').startup({function(use)
   use 'Mofiqul/dracula.nvim'
 
 
-  -- [[ Dev ]]
+  -- [[ Development ]]
   use {
-    'nvim-telescope/telescope.nvim',                 -- fuzzy finder
+    'nvim-telescope/telescope.nvim',  -- fuzzy finder
     requires = { {'nvim-lua/plenary.nvim'} }
   }
-  use { 'majutsushi/tagbar' }                        -- code structure
-  use { 'Yggdroot/indentLine' }                      -- see indentation
-  use { 'tpope/vim-fugitive' }                       -- git integration
-  use { 'junegunn/gv.vim' }                          -- commit history
-  use { 'windwp/nvim-autopairs' }
+  use { 'majutsushi/tagbar' }     -- code structure
+  use { 'Yggdroot/indentLine' }   -- see indentation
+  use { 'tpope/vim-fugitive' }    -- git integration
+  use { 'junegunn/gv.vim' }       -- commit history
+  use { 'windwp/nvim-autopairs' } -- automatically create pair of parenthes
 
   -- nvim-treesitter
   -- https://github.com/nvim-treesitter/nvim-treesitter/wiki/Installation#packernvim
@@ -78,28 +80,6 @@ return require('packer').startup({function(use)
         end,
   }
 
-  -- LSP based code folding
-  -- https://github.com/kevinhwang91/nvim-ufo
-  -- https://gist.github.com/mengwangk/a9a7d3bd855d3523b3a365236fc63290#file-plugins-lua
-  use {
-  "kevinhwang91/nvim-ufo",
-  opt = true,
-  event = { "BufReadPre" },
-  wants = { "promise-async" },
-  requires = "kevinhwang91/promise-async",
-  config = function()
-      require("ufo").setup {}
-
-      -- options for code foldng
-      vim.o.foldcolumn = '1' -- '0' is not bad
-      vim.o.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
-      vim.o.foldlevelstart = 99 -- also seen this set to -1 or 99
-      vim.o.foldenable = true
-
-      vim.keymap.set("n", "zR", require("ufo").openAllFolds)
-      vim.keymap.set("n", "zM", require("ufo").closeAllFolds)
-    end,
-  }
   -- START: Taken from https://sharksforarms.dev/posts/neovim-rust/
   -- used within jai.capabilities.lua for LSP capabilities
 
@@ -145,6 +125,6 @@ return require('packer').startup({function(use)
 
 end,
 config = {
-  package_root = vim.fn.stdpath('config') .. '/site/pack'
+  package_root = packer_path
 }})
 

--- a/lua/jai/rust.lua
+++ b/lua/jai/rust.lua
@@ -36,7 +36,7 @@ local opts = {
     },
     inlay_hints = {
       auto = true,
-      show_parameter_hints = false,
+      show_parameter_hints = true,
       parameter_hints_prefix = "",
       other_hints_prefix = "",
     },

--- a/lua/jai/treesitter.lua
+++ b/lua/jai/treesitter.lua
@@ -1,16 +1,21 @@
 -- [[ nvim-treesitter setup ]]
 -- https://github.com/nvim-treesitter/nvim-treesitter
 
--- setup treesitter based code folding
--- commented out due to using LSP based folding with nvim-ufo
+-- Treesitter Folding
+-- https://vimhelp.org/usr_28.txt.html
 -- https://alpha2phi.medium.com/neovim-for-beginners-code-folding-7574925412ea
--- local opt = vim.opt
--- opt.foldlevel = 20
--- opt.foldmethod = "expr"
--- opt.foldexpr = "nvim_treesitter#foldexpr()"
+-- commented out due to using LSP based folding with nvim-ufo
 
--- Below are currently default settings
+local opt = vim.opt
+
+opt.foldcolumn = "3"
+opt.foldlevel = 20  -- set to a high level so that by default most folds are open
+opt.foldmethod = "expr" -- allows for structured parsing to determine folds
+opt.foldexpr = "nvim_treesitter#foldexpr()"
+
+-- Below are mainly default settings
 require('nvim-treesitter.configs').setup {
+
   -- A list of parser names, or "all" (the listed parsers should always be installed)
   ensure_installed = {
     "lua",
@@ -21,7 +26,16 @@ require('nvim-treesitter.configs').setup {
     "toml",
     "javascript",
     "tsx",
-    "help"
+    "typescript",
+    "help",
+    "go",
+    "gitcommit",
+    "gitignore",
+    "git_rebase",
+    "dockerfile",
+    "jq",
+    "json",
+    "html"
   },
 
   -- Install parsers synchronously (only applied to `ensure_installed`)
@@ -32,7 +46,7 @@ require('nvim-treesitter.configs').setup {
   auto_install = true,
 
   -- List of parsers to ignore installing (for "all")
-  ignore_install = { "javascript" },
+  ignore_install = {},
 
   ---- If you need to change the installation directory of the parsers (see -> Advanced Setup)
   -- parser_install_dir = "/some/path/to/store/parsers", -- Remember to run vim.opt.runtimepath:append("/some/path/to/store/parsers")!
@@ -52,8 +66,6 @@ require('nvim-treesitter.configs').setup {
         local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
         if ok and stats and stats.size > max_filesize then
             return true
-        -- elseif lang == "javascript" then
-        --  return true
         end
     end,
 
@@ -64,6 +76,5 @@ require('nvim-treesitter.configs').setup {
     additional_vim_regex_highlighting = false,
   },
 }
-
 
 


### PR DESCRIPTION
remove nvim-ufo code folding and replace with nvim-treesitter folding instead. I will need to come back at a later date and improve the folding in general anyway. The way folds are displayed is currently not optimal.